### PR TITLE
Maintenance patch and fixes

### DIFF
--- a/openapi_generator/openapi_generator.py
+++ b/openapi_generator/openapi_generator.py
@@ -132,7 +132,7 @@ class OpenapiGenerator():
         """
         if extension == "json":
             with open(filename, 'w') as output_file:
-                json.dump(self.configs, output_file)
+                json.dump(self.configs, output_file, separators=(",", ":"))
         elif extension == "yaml":
             with open(filename, "w") as output_file:
                 output_file.write(yaml.dump(self.configs, default_flow_style=False))

--- a/openapi_generator/test_generator.py
+++ b/openapi_generator/test_generator.py
@@ -8,8 +8,8 @@ from openapi_spec_validator import openapi_v3_spec_validator
 
 class TestOpenapiGenerator(unittest.TestCase):
     def test_yaml_schema(self):
-        gen = OpenapiGenerator("Title", "Testing description", "0.0.1", "https://swapi.co")
-        response = requests.get("https://swapi.co/api/planets/", params={"page": 2})
+        gen = OpenapiGenerator("Title", "Testing description", "0.0.1", "https://swapi.dev")
+        response = requests.get("https://swapi.dev/api/planets/", params={"page": 2})
         gen.add_response(response)
         gen.export("example.yml", extension="yaml")
 
@@ -19,8 +19,8 @@ class TestOpenapiGenerator(unittest.TestCase):
         self.assertEqual(len(list(errors_iterator)), 0)
 
     def test_json_schema(self):
-        gen = OpenapiGenerator("Title", "Testing description", "0.0.1", "https://swapi.co")
-        response = requests.get("https://swapi.co/api/planets/", params={"page": 2})
+        gen = OpenapiGenerator("Title", "Testing description", "0.0.1", "https://swapi.dev")
+        response = requests.get("https://swapi.dev/api/planets/", params={"page": 2})
         gen.add_response(response)
         gen.export("example.json", extension="json")
 

--- a/openapi_generator/test_generator.py
+++ b/openapi_generator/test_generator.py
@@ -14,7 +14,7 @@ class TestOpenapiGenerator(unittest.TestCase):
         gen.export("example.yml", extension="yaml")
 
         with open("example.yml") as f:
-            spec = yaml.load(f)
+            spec = yaml.load(f, Loader=yaml.FullLoader)
         errors_iterator = openapi_v3_spec_validator.iter_errors(spec)
         self.assertEqual(len(list(errors_iterator)), 0)
 


### PR DESCRIPTION
### * Smaller JSON dump output using separators
>If specified, separators should be an (item_separator, key_separator) tuple. The default is (', ', ': ') if indent is None and (',', ': ') otherwise. To get the most compact JSON representation, you should specify (',', ':') to eliminate whitespace.

https://docs.python.org/2/library/json.html#json.dump
https://docs.python.org/3/library/json.html#json.dump

<hr>

### * Changed the test's URLs from https://swapi.co to https://swapi.dev
Change note from the devs: https://swapi.dev/about

<hr>

### * Removed warning about PyYAML load not specifying a loader
>Use of PyYAML's yaml.load function without specifying the Loader=... parameter, has been deprecated. In PyYAML version 5.1+, you will get a warning, but the function will still work.

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
